### PR TITLE
Use find_program() instead of files() for the run-test script

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4,7 +4,7 @@ test_env = [
   'TEST_DIR=' + meson.current_source_dir()
 ]
 
-run_test = files('run-test')
+run_test = find_program('run-test')
 
 tests = [
   'umpf-init',


### PR DESCRIPTION
Explicitly find the run-test shell script once, instead of implicitly each time the file list is passed to test().