### PR TITLE
Add ternary conditional operator support to Meson project version fixup

### DIFF
--- a/umpf
+++ b/umpf
@@ -1026,7 +1026,9 @@ rebase_end() {
 		s{
 		    \b(project\(
 		        (?<expr_comma>
-		            (?<expr>\s*
+		          (?<expr>
+		           (
+		            (?<expr_noternary>\s*
 		                ( (?<identifier>[a-zA-Z0-9_]++) # an identifier
 		                | ' [^']*+                     ' # a non-nested single quoted string
 		                | " [^"]*+                     " #              double
@@ -1042,7 +1044,10 @@ rebase_end() {
 		                    ) \)
 		                | \.                             # struct members etc.
 		                )*                               # function name + arguments etc.
-		            \s*),\s*
+		            \s*)
+		           | (?&expr_noternary) \? (?&expr_noternary) : (?&expr)
+		           )
+		          ),\s*
 		        )*+
 		        (
 		            (?!version[\s:])


### PR DESCRIPTION
Add support for the ternary conditional operator to the Perl regular expression that is used to append the project version in meson.build files.

This is required for Mesa 23.0.0-rc1 and later, to support the following expression:
```
meson.version().version_compare('>= 0.56') ? meson.project_source_root() : meson.source_root()
```

Edit: It looks like this will be required for Mesa 23.0.x but not for later versions.