### PR TITLE
Add support for trusted-firmware-a releases

### DIFF
--- a/umpf
+++ b/umpf
@@ -1010,6 +1010,10 @@ rebase_end() {
 
 		sed -i -r "s:^(EXTRAVERSION =.*)\$:\1-${version}:" Makefile
 		git add Makefile
+	elif grep -sq '^VERSION_STRING\s*:=' Makefile; then
+
+		sed -i -r "s;^(VERSION_STRING\s*:=.*)\$;\1-${version};" Makefile
+		git add Makefile
 	fi
 	if version_file="$(grep -l AC_INIT configure.* 2>/dev/null)"; then
 		perl -0777 -i -p -e "s/\b(AC_INIT\()(\[[^\]]*\]|[^),]*)(\s*,\s*)(\[[^\]]*|[^,]*)(\]?[^)]*\))/\1\2\3\4.${version}\5/" "${version_file}"


### PR DESCRIPTION
The Makefile for the trusted-firmware-a software is a bit special since it has no EXTAVERSION variable instead they use a VERSION_STRING variable. The variable is composed by:
```
# Default build string (git branch and commit)
ifeq (${BUILD_STRING},)
        BUILD_STRING  :=  $(shell git describe --always --dirty --tags 2> /dev/null)
endif
VERSION_STRING    :=  v${VERSION_MAJOR}.${VERSION_MINOR}(${BUILD_TYPE}):${BUILD_STRING}
```
Append the final VERSION_STRING variable with the umpf version to be independent of the set/not set BUILD_STRING variable.

The output before this patch was (BUILD_STRING not set):
```
NOTICE:  BL31: v2.7(release):v2.7
```
With this patch applied the output will be:
```
NOTICE:  BL31: v2.7(release):v2.7-20221109-2
```
Signed-off-by: Marco Felsch <m.felsch@pengutronix.de>