### PR TITLE
tests: use checkout instead of switch

### DIFF
--- a/tests/umpf-distribute
+++ b/tests/umpf-distribute
@@ -4,7 +4,7 @@
 # "umpf distribute".
 #
 
-git switch -c work umpf-build
+git checkout -b work umpf-build
 echo "a2" >> a.txt && git add a.txt && git commit -m "a2"
 echo "b2" >> b.txt && git add b.txt && git commit -m "b2"
 


### PR DESCRIPTION
"git checkout" is not available in older git versions.