### PR TITLE
Fix umpf-distribute test

### DIFF
--- a/tests/umpf-distribute
+++ b/tests/umpf-distribute
@@ -8,8 +8,11 @@ git switch -c work umpf-build
 echo "a2" >> a.txt && git add a.txt && git commit -m "a2"
 echo "b2" >> b.txt && git add b.txt && git commit -m "b2"
 
-umpf distribute --remote=refs/heads <<EOF
+umpf distribute --remote=refs/heads --base=base <<EOF
 0
 1
 
 EOF
+
+test $(git rev-list origin/a..a | wc -l) -eq 1
+test $(git rev-list origin/b..b | wc -l) -eq 1


### PR DESCRIPTION
Add the missing --base parameter and make sure that each branch actually received one patch.