### PR TITLE
umpf: suppress umpf-distribute errors when there is no diff

### DIFF
--- a/umpf
+++ b/umpf
@@ -1593,6 +1593,13 @@ do_distribute() {
 	echo "${SERIES}" > "${STATE}/head"
 	parse_series diff "${STATE}/series"
 
+	if [ ! -e "${STATE}/diff" ]; then
+		info
+		info "No new patches to distribute"
+		cleanup
+		return
+	fi
+
 	if ${IDENTICAL} && [ ! -e "${STATE}/topics" ]; then
 		abort "Identical diff requires series with 'hashinfo'"
 	fi


### PR DESCRIPTION
If one runs umpf-distribute with no new patches added, the script outputs some benign but ugly errors and prompts for user input when there is nothing to do. Example:

    linux $ umpf distribute
    umpf: Using series from commit message...
    umpf: Remote undefined. Choose the branch with the correct remote:
    0) yoyo/v6.1/topic/fixes
    1) v6.1/topic/fixes
    branch number: 0
    umpf: Using remote 'yoyo/'.
    /home/alvin/bin/umpf: line 1570: .git/umpf/diff: No such file or directory
    /home/alvin/bin/umpf: line 1571: ${patches_in}: ambiguous redirect
    /home/alvin/bin/umpf: line 1576: patches_in: ambiguous redirect

    umpf: Updating remote topic branches for 'yoyo/'...
    Press Enter to continue.
    linux $

To improve the user experience, check if there is no diff, and in that case print a friendly info message instead. Example:

    linux $ umpf distribute
    umpf: Using series from commit message...
    umpf: Remote undefined. Choose the branch with the correct remote:
    0) yoyo/v6.1/topic/fixes
    1) v6.1/topic/fixes
    branch number: 0
    umpf: Using remote 'yoyo/'.

    umpf: No new patches to distribute
    linux $