### PR TITLE
umpf: add branch choice in case of additional commits

### DIFF
--- a/umpf
+++ b/umpf
@@ -391,7 +391,11 @@ find_branch_rev() {
 			info "Warning: The following commits are in '${branch}' but not in '${remote}${name}':"
 			GIT_PAGER="" ${GIT} log --oneline "${reply}...${b}"
 			if tty -s; then
-				read -p "Press Enter to continue."
+				local choice=""
+				read -e -i n -p "Use ${branch} instead? [y/n]: " choice
+				if [ "${choice}" == "y" ]; then
+					reply="${branch}"
+				fi
 			fi
 		fi
 	done


### PR DESCRIPTION
When umpf compares branches between all of the known remotes, it warns when a discovered branch includes additional commits compared to the one on the selected remote. The user is warned, but has no choice to use the alternative remote and include the commits.

This commit adds a choice to the user in the situation described above. This is useful to facilitate generating an umpf-tag with some local changes when working on projects with multiple developers pushing to the same common branches, i.e. where the remote is not to be updated until the changes are verified and ready to merge.