### PR TITLE
umpf: add new --override option to override topic commit-ish

### DIFF
--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -16,15 +16,27 @@ reproduce an umpf!
 Use ``--identical`` only for specific branches (but use tip-of-head for others)
 -------------------------------------------------------------------------------
 
-Currently, ``--identical`` will always use the hashinfo for all branches.
+By default, ``--identical`` will always use the hashinfo for all branches.
+This can be overridden case by case with the ``--override`` option.
+For example, to use the local state of only the ``v4.19/topic/imx-poweroff``
+branch, but use ``acme`` remote for everything else::
 
-Workround 1: reset all local topic branches that are included in the umpf to their
-desired commit, then let umpf prompt for the remote for every single branch
-(see above), and select the local branch.
+  umpf --identical --remote acme --override v4.19/topic/imx-poweroff build series
 
-Workaround 2: If the same state is needed on future umpfs (e.g. with stable workflows),
-create a separate branch in the ``vX.Y/customers/`` namespace on the desired commit,
-which you can then refer to in your *useries* file or with ``umpf merge``.
+In cases, where the local branch is named differently, this can be made
+explicit::
+
+  umpf --identical --remote acme --override \
+    v4.19/topic/imx-poweroff=v4.19/topic/poweroff-rework build series
+
+Normally, this state is needed for future umpfs and thus ``--override`` should
+be a temporary measure until the remote branches are updated and future
+umpfs yield the same result without ``--override``.
+
+If the topic branches are shared between different project and a branch needs
+to be stabilized, a separate branch in the ``vX.Y/customers/`` namespace can
+be created pointing at the desired commit.
+This can then be referred to in the *useries* file or with ``umpf merge``.
 Example (with ``umpf-topic: v4.19/customers/foobar/topic/imx-poweroff``)::
 
   $ git log --oneline --decorate ${base}^..origin/v4.19/topic/imx-poweroff
@@ -35,5 +47,5 @@ Example (with ``umpf-topic: v4.19/customers/foobar/topic/imx-poweroff``)::
   * ba0390a910e7 ARM: imx6q: provide documentation for new fsl,pmic-stby-poweroff property
   * c63ee2939dc1 (tag: v4.19.85) Linux 4.19.85
 
-This way you are independent of future updates of the
+This way renewed umpfs are independent of future updates of the
 ``v4.19/topic/imx-poweroff`` topic branch.

--- a/umpf
+++ b/umpf
@@ -41,6 +41,7 @@ VERSION=1
 AUTO_RERERE=false
 BLOCK_SIZE=100
 BB=false
+declare -A OVERRIDES
 
 # Create a pristine environment to minimize unnecessary fuzz when different
 # users use umpf on the same patch stack. That is, don't load any config files,
@@ -99,6 +100,7 @@ bailout() {
 		if ${FORCE}; then
 			echo "FORCE=true" >> "${STATE}/config"
 		fi
+		declare -p OVERRIDES >> "${STATE}/config"
 	fi
 
 	if [ -n "$*" ]; then
@@ -159,6 +161,11 @@ usage() {
 	  -p, --patchdir <path>      with format-patch: write patches to <path>/
 	      --relative <path>      create patches relative to <path>
 	  -r, --remote <remote>      use <remote> to resolve branch names
+	      --override <topic>[=<commit-ish>]
+	                             use commit-ish instead for the topic. May be
+				     specified more than once. If only <topic> is
+				     specified, it's interpreted as
+				     <topic>=<remote>/<topic>
 	  -u, --update               with --patchdir: update existing patches in <path>
 	  -v, --version <version>    with tag: overwrite version number [default: 1]
 
@@ -191,7 +198,7 @@ EOF
 ### setup ###
 
 setup() {
-	local tmp args o l
+	local tmp args o l topic commitish
 	if tmp="$(git config umpf.patch-dir)"; then
 		PATCH_DIR="${tmp}"
 	fi
@@ -206,7 +213,7 @@ setup() {
 	fi
 
 	o="fhisub:n:p:r:v:"
-	l="auto-rerere,bb,force,help,identical,stable,update,base:,name:,patchdir:,relative:,remote:,version:"
+	l="auto-rerere,bb,force,help,identical,stable,update,base:,name:,patchdir:,relative:,override:,remote:,version:"
 	if ! args="$(getopt -n umpf -o "${o}" -l "${l}" -- "${@}")"; then
 		usage
 		exit 1
@@ -263,6 +270,15 @@ setup() {
 			GIT_REMOTE="${1}"
 			shift
 			;;
+		--override)
+			IFS="=" read -r topic commitish <<< "${1}"
+			if [ -n "${commitish}" ]; then
+				OVERRIDES[$topic]="${commitish}"
+			else
+				OVERRIDES[$topic]=""
+			fi
+			shift
+			;;
 		-v|--version)
 			VERSION="${1}"
 			shift
@@ -288,6 +304,21 @@ setup() {
 	if [ -n "${GIT_FALLBACK_REMOTE}" ]; then
 		GIT_FALLBACK_REMOTE="${GIT_FALLBACK_REMOTE}/"
 	fi
+
+	for topic in "${!OVERRIDES[@]}"; do
+		local rev
+
+		if [ -z "${OVERRIDES[$topic]}" ]; then
+			OVERRIDES[$topic]="${GIT_REMOTE}/${topic}"
+		fi
+
+		if ! rev="$(${GIT} rev-parse "${OVERRIDES[$topic]}^{}" 2> /dev/null)"; then
+			echo "Revision '${OVERRIDES[$topic]}' not found for topic '${topic}'"
+			exit 1
+		fi
+
+		OVERRIDES[$topic]="${rev}"
+	done
 }
 
 prepare() {
@@ -341,6 +372,10 @@ find_branch_rev() {
 	local name branch remote
 	local -a branches replies
 	name="${1}"
+	if [ -n "${OVERRIDES[$name]}" ]; then
+	        reply="${OVERRIDES[$name]}"
+		return
+	fi
 	if ${IDENTICAL}; then
 		reply="${2}"
 		return


### PR DESCRIPTION
In one project, umpf tags are pushed immediately, but branches are only pushed upstream once they are reviewed and cleared for merge into BSP. It's thus often the case, that developers want to use the upstream branches, except for that one branch they are currently working on.

This is not an unusual case and the tips-and-tricks lists some workarounds to achieve this. Provide a better way by allowing overriding single topic branches on the command-line.