### PR TITLE
umpf: call rev-parse on manually selected local branches as well

### DIFF
--- a/umpf
+++ b/umpf
@@ -394,7 +394,7 @@ find_branch_rev() {
 				local choice=""
 				read -e -i n -p "Use ${branch} instead? [y/n]: " choice
 				if [ "${choice}" == "y" ]; then
-					reply="${branch}"
+					reply="${b}"
 				fi
 			fi
 		fi


### PR DESCRIPTION
When umpf compares branches between all of the known remotes, it will now prompt the user when it discovers a branch that includes additional commits compared to the one on the selected remote.

If the user confirms, the branch name is taken as is, which would result in an umpf-hashinfo of e.g. heads/v6.4/topic/something, which breaks the ability of doing identical umpfs.

To restore that ability, we need to call rev-parse on the ${branch}.

Fixes: 000e642bc702 ("umpf: add branch choice in case of additional commits")