### PR TITLE
Properly squash commits created by git commit --fixup=amend:$rev

### DIFF
--- a/umpf
+++ b/umpf
@@ -992,7 +992,7 @@ rebase_branch() {
 		echo "# umpf-hashinfo: ${topicrev}" >&${series_out}
 
 		${GIT} rev-parse HEAD > "${STATE}/prev_head"
-		if ${GIT} log --oneline "${base}..${topicrev}" | grep -q '\(fixup\|squash\)!'; then
+		if ${GIT} log --oneline "${base}..${topicrev}" | grep -q '\(amend\|fixup\|squash\)!'; then
 			args="-i --autosquash"
 		fi
 		if ! ${GIT} rebase -q ${args} --onto HEAD "${base}" "${topicrev}" >&2; then


### PR DESCRIPTION
git commit --fixup=amend:$rev allows to overwrite the commit message of a previous commit. This results in a commit with prefix "amend!". Expand the pattern that triggers using git rebase -i --autosquash to also match on such commits.