### PR TITLE
README: Formalize signing off commits

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,8 +52,48 @@ More details about umpf can be found in the documentation.
 * `umpf from the Inside`_
 * `Tips and Tricks`_
 
+License and Developing
+======================
+
+To contribute to umpf please prepare a pull request on Github. To make
+is possible to include your modifications it's required that your code
+additions are licensed under the same terms as umpf itself. So you are
+required to agree to the following document:
+
+  Developer's Certificate of Origin 1.1
+
+  By making a contribution to this project, I certify that:
+
+  (a) The contribution was created in whole or in part by me and I
+      have the right to submit it under the open source license
+      indicated in the file; or
+
+  (b) The contribution is based upon previous work that, to the best
+      of my knowledge, is covered under an appropriate open source
+      license and I have the right under that license to submit that
+      work with modifications, whether created in whole or in part
+      by me, under the same open source license (unless I am
+      permitted to submit under a different license), as indicated
+      in the file; or
+
+  (c) The contribution was provided directly to me by some other
+      person who certified (a), (b) or (c) and I have not modified
+      it.
+
+  (d) I understand and agree that this project and the contribution
+      are public and that a record of the contribution (including all
+      personal information I submit with it, including my sign-off) is
+      maintained indefinitely and may be redistributed consistent with
+      this project or the open source license(s) involved.
+
+Your agreement is expressed by adding a sign-off line to each of your
+commits (e.g. using ``git commit -s``) looking as follows:
+
+        Signed-off-by: Random J Developer <random@developer.example.org>
+
+with your identity and email address matching the commit meta data.
+
 .. _`What is an umpf?`: doc/what-is-an-umpf.rst
 .. _`Getting Started`: doc/getting-started.rst
 .. _`Tips and Tricks`: doc/tips.rst
 .. _`umpf from the Inside`: doc/inner-workings.rst
-


### PR DESCRIPTION
The automatic checks for pull requests on Github include a check that fails if a Signed-off-by: line by the commiter is missing in any commit.

For that to make sense formalize the meaning of such a line. I'm not a lawyer (thank heavens!) but I believe that without such a formalisation you cannot safely assume the "usual semantic also used in other open-source projects".