### PR TITLE
umpf: fix losing flags while continue

### DIFF
--- a/umpf
+++ b/umpf
@@ -104,7 +104,7 @@ bailout() {
 		IDENTICAL="${IDENTICAL}"
 		STABLE="${STABLE}"
 		UPDATE="${UPDATE}"
-		FLAGS="${FLAGS}"
+		FLAGS="$(<"${STATE}/flags")"
 		VERSION_SEPARATOR="${VERSION_SEPARATOR}"
 		VERSION="${VERSION}"
 		EOF
@@ -210,7 +210,7 @@ EOF
 ### setup ###
 
 setup() {
-	local tmp args o l topic commitish
+	local tmp args o l topic commitish content
 	if tmp="$(git config umpf.patch-dir)"; then
 		PATCH_DIR="${tmp}"
 	fi
@@ -319,6 +319,11 @@ setup() {
 	fi
 	if [ -n "${GIT_FALLBACK_REMOTE}" ]; then
 		GIT_FALLBACK_REMOTE="${GIT_FALLBACK_REMOTE}/"
+	fi
+
+	if [ -n "${FLAGS}" ] || [ -f "${STATE}/flags" ]; then
+		content=${FLAGS:-$(<"${STATE}/flags")}
+		check_flags
 	fi
 
 	for topic in "${!OVERRIDES[@]}"; do


### PR DESCRIPTION
The 'umpf continue' case was tested only with the use-case where flags are specified via the cmdline. If flags are provided via an useries file they are still lost. Fix this by making use of the new flags status file while bailout(). This file is always generated.

This commit also fixes the case the following case: flags were succefull verified but umpf fails later on e.g. during a tag run and we would need to run 'umpf continue'. In such case they are marked within the ${STATE}/done file so the hooks are not executed again. Fix this by checking for the FLAGS cmdline parameter or the new ${STATE}/flags file to parse and setup the flags everytime.