### PR TITLE
umpf: output version infos to bitbake variables during format-patch

### DIFF
--- a/tests/series-format-patch-bb.ref
+++ b/tests/series-format-patch-bb.ref
@@ -13,4 +13,7 @@ SRC_URI += "\
 SRC_URI += "\
   file://patches/0101-b1.patch \
   "
+UMPF_BASE = "base"
+UMPF_VERSION = "20221209-1"
+PV = "${UMPF_BASE}-${UMPF_VERSION}"
 # umpf-end

--- a/umpf
+++ b/umpf
@@ -1414,6 +1414,15 @@ format_patch_end() {
 	if ${NIX}; then
 		echo "]" >&${series_out}
 	fi
+	if ${BB}; then
+		local base_name="$(<"${STATE}/base-name")"
+		echo "UMPF_BASE = \"${base_name//v/}\"" >&${series_out}
+		echo "UMPF_VERSION = \"$(<"${STATE}/version")\"" >&${series_out}
+		echo "PV = \"\${UMPF_BASE}-\${UMPF_VERSION}\"" >&${series_out}
+		if [ "$(head -n 1 README 2>/dev/null)" = "Linux kernel" ]; then
+			echo "LINUX_VERSION = \"\${UMPF_BASE}\"" >&${series_out}
+		fi
+	fi
 	echo "$line" >&${series_out}
 }
 


### PR DESCRIPTION
This sets PV to the exact umpf version.

This is especially useful when using the series.inc together with the linux-yocto.bbclass version checking which expects PV to match the full kernel version.