### PR TITLE
tig: add subcommand to browse an umpf and its context interactively

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -38,7 +38,7 @@ _umpf_completion()
 	"")
 		COMPREPLY=( $( compgen -W "${completion_cmds[*]} help" -- $cur ) )
 		;;
-	diff|show|tag|build)
+	diff|show|tag|tig|build)
 		local -a refs
 		refs=( $( compgen -W "$( git for-each-ref --format='%(refname:short)' refs/tags refs/heads refs/remotes)" -- $cur ) )
 		if [ ${#refs[@]} -eq 0 ]; then

--- a/umpf
+++ b/umpf
@@ -200,6 +200,8 @@ usage() {
 	  diff <commit-ish>          show patches not in any topic branch (not
 	                             upstream) and patches missing locally
 	  show <commit-ish>          show an useries file from an umpf
+	  tig [umpf]                 browse an umpf interactively, showing state of
+	                             local, remote and remote-tracking topic branches
 
 	  tag <commit-ish>           generate a utag from an umerge
 	  format-patch <utag>        generate a useries file and patch stack
@@ -1871,6 +1873,38 @@ do_abort() {
 do_show() {
 	VERBOSE=true
 	prepare_persistent show "${@}"
+	cleanup
+}
+
+### namespace: tig ###
+
+tig_topic() {
+	${GIT} show-ref -s "${content}" >> "${STATE}/refs"
+}
+
+tig_release() {
+	echo "${content}" >> "${STATE}/refs"
+}
+
+tig_hashinfo() {
+	echo "${content}" >> "${STATE}/refs"
+}
+
+### command: tig ###
+
+do_tig () {
+	local -a refs
+	local base
+
+	prepare_persistent tig "${@}"
+	parse_series tig "${STATE}/series"
+
+	mapfile -t refs < "${STATE}/refs"
+	base="$(<"${STATE}/base-name")"
+
+	# cut off each ref at base
+	tig ^"${base}"^ "${refs[@]}"
+
 	cleanup
 }
 


### PR DESCRIPTION
The 'tig' subcommand makes it possible to browse an umpf interactively while showing the local and remote state of all topic branches. This can give an overview how the topic branches have developed before building another umpf.

For simplicity sake, also limit the range of the topics to the history leading up from the umpf-base.