### PR TITLE
umpf: do not set PV in series.inc

### DIFF
--- a/tests/series-format-patch-bb.ref
+++ b/tests/series-format-patch-bb.ref
@@ -15,5 +15,5 @@ SRC_URI += "\
   "
 UMPF_BASE = "base"
 UMPF_VERSION = "20240314-2"
-PV = "${UMPF_BASE}-${UMPF_VERSION}"
+UMPF_PV = "${UMPF_BASE}-${UMPF_VERSION}"
 # umpf-end

--- a/umpf
+++ b/umpf
@@ -1422,7 +1422,7 @@ format_patch_end() {
 		local base_name="$(<"${STATE}/base-name")"
 		echo "UMPF_BASE = \"${base_name//v/}\"" >&${series_out}
 		echo "UMPF_VERSION = \"$(<"${STATE}/version")\"" >&${series_out}
-		echo "PV = \"\${UMPF_BASE}-\${UMPF_VERSION}\"" >&${series_out}
+		echo "UMPF_PV = \"\${UMPF_BASE}-\${UMPF_VERSION}\"" >&${series_out}
 		if [ "$(head -n 1 README 2>/dev/null)" = "Linux kernel" ]; then
 			echo "LINUX_VERSION = \"\${UMPF_BASE}\"" >&${series_out}
 		fi


### PR DESCRIPTION
Since most recipes tend to use PV in their `SRC_URI` and we cannot set it as a default value (`?=`), it is the safest way to not set it automatically from series.inc.

Users who want to have UMPF_VERSION as part of the yocto package version can manually set PV to

    PV = "${UMPF_BASE}-${UMPF_VERSION}

at an appropriate location within the recipe.