### PR TITLE
Skip empty commits for umpf-tags

### DIFF
--- a/umpf
+++ b/umpf
@@ -1083,7 +1083,7 @@ rebase_branch() {
 		if ${GIT} log --oneline "${base}..${topicrev}" | grep -q '\(amend\|fixup\|squash\)!'; then
 			args="-i --autosquash"
 		fi
-		if ! ${GIT} rebase -q ${args} --onto HEAD "${base}" "${topicrev}" >&2; then
+		if ! ${GIT} rebase -q ${args} --no-keep-empty --onto HEAD "${base}" "${topicrev}" >&2; then
 			if ! rebase_try_continue; then
 				bailout "rebase failed"
 			fi


### PR DESCRIPTION
There are cases where topic branches do have empty commits e.g. if the topic branches are managed via b4 [1]. b4 uses empty commits to track metadata. This is useful for topic branch management but shouldn't be part of the final umpf-tag. Therefore add --no-keep-empty to skip empty commits during the rebase.

[1] https://github.com/mricon/b4