### PR TITLE
format-patch: if patchdir is a symlink, keep it intact

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -38,7 +38,7 @@ _umpf_completion()
 	"")
 		COMPREPLY=( $( compgen -W "${completion_cmds[*]} help" -- $cur ) )
 		;;
-	diff|show|tag|build)
+	diff|show|tag|tig|build)
 		local -a refs
 		refs=( $( compgen -W "$( git for-each-ref --format='%(refname:short)' refs/tags refs/heads refs/remotes)" -- $cur ) )
 		if [ ${#refs[@]} -eq 0 ]; then

--- a/umpf
+++ b/umpf
@@ -200,6 +200,8 @@ usage() {
 	  diff <commit-ish>          show patches not in any topic branch (not
 	                             upstream) and patches missing locally
 	  show <commit-ish>          show an useries file from an umpf
+	  tig [umpf]                 browse an umpf interactively, showing state of
+	                             local, remote and remote-tracking topic branches
 
 	  tag <commit-ish>           generate a utag from an umerge
 	  format-patch <utag>        generate a useries file and patch stack
@@ -1871,6 +1873,56 @@ do_abort() {
 do_show() {
 	VERBOSE=true
 	prepare_persistent show "${@}"
+	cleanup
+}
+
+### namespace: tig ###
+
+tig_topic() {
+	local reply
+	find_branch_rev "${content}"
+	if [ -n "${reply}" ]; then
+		echo "${reply}" >> "${STATE}/refs"
+	fi
+
+	# possibly-existing local topic branch
+	if ${GIT} rev-parse --verify -q "${content}" >/dev/null 2>&1; then
+		echo "${content}" >> "${STATE}/refs"
+	fi
+
+	# possibly-existing remote-tracking topic branch
+	# (might be different from the remote chosen above)
+	if ${GIT} rev-parse --verify -q "${content}@{u}" >/dev/null 2>&1; then
+		echo "${content}@{u}" >> "${STATE}/refs"
+	fi
+}
+
+tig_release() {
+	echo "${content}" >> "${STATE}/refs"
+}
+
+tig_hashinfo() {
+	echo "${content}" >> "${STATE}/refs"
+}
+
+### command: tig ###
+
+do_tig () {
+	local refs base ranges
+
+	prepare_persistent tig "${@}"
+	parse_series tig "${STATE}/series"
+
+	mapfile -t refs < "${STATE}/refs"
+	base="$(<"${STATE}/base-name")"
+	ranges=
+
+	# cut off each ref at base
+	for ref in "${refs[@]}"; do
+		ranges="${ranges} ${base}^..${ref}"
+	done
+
+	tig ${ranges}
 	cleanup
 }
 

--- a/umpf
+++ b/umpf
@@ -1480,7 +1480,7 @@ run_format_patch() {
 	exec {series_out}<&-
 	unset series_out
 
-	mkdir -p "${PATCH_DIR}" ||  bailout "Failed to create patch dir"
+	mkdir -p "$(realpath -m ${PATCH_DIR})" ||  bailout "Failed to create patch dir"
 	for patch in "${STATE}/patches/"*; do
 		tail -n+2 "${patch}" > "${PATCH_DIR}/$(basename "${patch}")"
 	done
@@ -1522,7 +1522,7 @@ do_format_patch() {
 			remove_patches "${line}"
 		done < "${OLD_SERIES}"
 	elif ${FORCE} &&  [ -d "${PATCH_DIR}" ]; then
-		rm -r "${PATCH_DIR}" || abort "Failed to remove old patch dir"
+		rm -r "$(realpath -m ${PATCH_DIR})" || abort "Failed to remove old patch dir"
 	elif [ -d "${PATCH_DIR}" ]; then
 		abort "patch dir '${PATCH_DIR}' exists!"
 	fi


### PR DESCRIPTION
If the patch dir is a symlink, overwrite the folder to which it points instead of removing the symlink.

For further explanation: I have several git worktrees that I use to keep different projects checked out at the same time. In there, I usually keep a folder named `bsp-patches` pointing to the BSP patch directory to save my from typing the whole path all over again (which especially in Yocto projects can still take a lot of tab key presses). So I'd only like to do `umpf tag -fp bsp-patches/`.
