### PR TITLE
umpf: make LINUX_VERSION a weak assignment

### DIFF
--- a/umpf
+++ b/umpf
@@ -1459,7 +1459,7 @@ format_patch_end() {
 		echo "UMPF_VERSION = \"$(<"${STATE}/version")\"" >&${series_out}
 		echo "UMPF_PV = \"\${UMPF_BASE}-\${UMPF_VERSION}\"" >&${series_out}
 		if [ "$(head -n 1 README 2>/dev/null)" = "Linux kernel" ]; then
-			echo "LINUX_VERSION = \"\${UMPF_BASE}\"" >&${series_out}
+			echo "LINUX_VERSION ?= \"\${UMPF_BASE}\"" >&${series_out}
 		fi
 	fi
 	echo "$line" >&${series_out}


### PR DESCRIPTION
Umpf already supports stable updates outside of umpf if the extraversion=conflictfree was provided for the umpf-tag.

This patch allow the Yocto users to override LINUX_VERSION from anywhere within a recipe which can be the case if the initial umpf-tag was provided by another team than the one doing the maintenance work (stable updates).