### PR TITLE
umpf: write umpf patches into separate bitbake variable

### DIFF
--- a/tests/series-format-patch-bb.ref
+++ b/tests/series-format-patch-bb.ref
@@ -4,15 +4,17 @@
 # umpf-topic: a
 # umpf-hashinfo: f46ed0419d2c31ed10f978cc461e0d1ae4b3b426
 # umpf-topic-range: d306da785d874c09b89264d3f71632bc14bfe51f..b2b9f854952b0be84ba2472f236783d09bfa6561
-SRC_URI += "\
+UMPF_SRC_URI += "\
   file://patches/0001-a1.patch \
   "
 # umpf-topic: b
 # umpf-hashinfo: 3755a03cf640725df1aeb13789cba87154a47b04
 # umpf-topic-range: b2b9f854952b0be84ba2472f236783d09bfa6561..e791a2bb22e021b8513809e1e1cbf692be74fd99
-SRC_URI += "\
+UMPF_SRC_URI += "\
   file://patches/0101-b1.patch \
   "
+SRC_URI += "${UMPF_SRC_URI}"
+
 UMPF_BASE = "base"
 UMPF_VERSION = "20240314-2"
 UMPF_PV = "${UMPF_BASE}-${UMPF_VERSION}"

--- a/umpf
+++ b/umpf
@@ -1425,7 +1425,7 @@ format_patch_hashinfo() {
 
 filter_patches() {
 	if ${BB}; then
-		echo 'SRC_URI += "\'
+		echo 'UMPF_SRC_URI += "\'
 		sed "s,^${STATE}/\(.*\)$,  file://\1 \\\\,"
 		echo '  "'
 	elif ${NIX}; then
@@ -1457,6 +1457,8 @@ format_patch_end() {
 	fi
 	if ${BB}; then
 		local base_name="$(<"${STATE}/base-name")"
+		echo "SRC_URI += \"\${UMPF_SRC_URI}\"" >&${series_out}
+		echo "" >&${series_out}
 		echo "UMPF_BASE = \"${base_name//v/}\"" >&${series_out}
 		echo "UMPF_VERSION = \"$(<"${STATE}/version")\"" >&${series_out}
 		echo "UMPF_PV = \"\${UMPF_BASE}-\${UMPF_VERSION}\"" >&${series_out}


### PR DESCRIPTION
This will put all umpf-relates SRC_URI adaptions into the variable UMPF_SRC_URI, which potentially allows separating them from other SRC_URI entries (and patches).

With this, one can simply deactivate the umpf patches by setting

    UMPF_SRC_URI = ""