### PR TITLE
umpf: keep the first commit-ish for a branch when creating the umpf from an umerge

### DIFF
--- a/umpf
+++ b/umpf
@@ -700,8 +700,8 @@ import_series() {
 			branch_names[${#branch_names[@]}]="${name}"
 			branch_squashes[${name}]="${squash}"
 			names="${names}${name}#"
+			tmp_branches[${name}]="${branch}"
 		fi
-		tmp_branches[${name}]="${branch}"
 	done
 	for name in "${branch_names[@]}"; do
 		branch="${tmp_branches[${name}]}"


### PR DESCRIPTION
When an umpf is created from a umerge, the same topic branch may be found multiple times:
1. The actual merge for the topic in the umerge
2. as a base for another topic

The commit-ish from the first case is the relevant one. All others may use older versions of the topic branch, so ignore those when creating the useries.

Without this, creating an identical tag from a umerge will use the wrong version of the topic branch.