### PR TITLE
umpf: add special version handling for optee

### DIFF
--- a/umpf
+++ b/umpf
@@ -1207,6 +1207,10 @@ rebase_end() {
 
 		sed -i -r "s;^(VERSION_STRING\s*:=.*)\$;\1-${version};" Makefile
 		git add Makefile
+	elif grep -sq '^CFG_OPTEE_REVISION_EXTRA\s*?=' mk/config.mk; then
+
+		sed -i -r "s;^(CFG_OPTEE_REVISION_EXTRA\s*\?=.*)\$;\1-${version};" mk/config.mk
+		git add mk/config.mk
 	fi
 	if version_file="$(grep -l AC_INIT configure.* 2>/dev/null)"; then
 		perl -0777 -i -p -e "s/\b(AC_INIT\()(\[[^\]]*\]|[^),]*)(\s*,\s*)(\[[^\]]*|[^,]*)(\]?[^)]*\))/\1\2\3\4.${version}\5/" "${version_file}"


### PR DESCRIPTION
Optee has its own special version handling, that now can be tracked.