### PR TITLE
umpf: push umpf-base as well

### DIFF
--- a/umpf
+++ b/umpf
@@ -1895,6 +1895,10 @@ do_distribute() {
 
 ### namespace: push ###
 
+push_base() {
+	echo "${content}" > "${STATE}/base-name"
+}
+
 push_topic() {
 	echo "${content}" >> "${STATE}/topic-names"
 }
@@ -1936,6 +1940,7 @@ do_push () {
 	prepare_persistent push "${@}"
 	parse_series push "${STATE}/series"
 
+	local base="$(<"${STATE}/base-name")"
 	local tagname="$(<"${STATE}/tagname")"
 	local tagrevf="$(<"${STATE}/tagrev-flat")"
 
@@ -1992,7 +1997,10 @@ do_push () {
 		args+=("${topics[$topic]}:${topic}")
 	done
 
-	# Push tag again to avoid an error if $args is empty
+	if [ -n "$(${GIT} rev-parse --symbolic-full-name "${base}")" ]; then
+		args+=("${base}")
+	fi
+
 	${GIT} push "${opts[@]}" ${remote} -- "${tagname}" "${args[@]}"
 
 	cleanup


### PR DESCRIPTION
umpf-base is often a tag from a different repository, which may not be available (or added as remote) to everyone trying to rebuild an umpf.

Let's push the base too to make it possible to reproduce the umpf.

---
I chose to keep the tagname push anyway as we may want to add a mode that skips the check that the tag was already pushed.