### PR TITLE
umpf: propagate umpf push exit code

### DIFF
--- a/umpf
+++ b/umpf
@@ -160,6 +160,8 @@ abort() {
 }
 
 cleanup() {
+	local ret=$?
+
 	if [ -n "${series_out}" ]; then
 		exec {series_out}<&-
 		unset series_out
@@ -170,6 +172,8 @@ cleanup() {
 	fi
 	rm -rf "${GIT_DIR}/refs/umpf"
 	rm -rf "${STATE}"
+
+	return ${ret}
 }
 
 usage() {


### PR DESCRIPTION
An umpf push that fails at the final git push step does not exit with an error status.

This makes it difficult to use umpf push in a CI setup, where no one looks at job output if the job did not signal an error.

Propagate the error code to fix this.

Reported-by: Leonard Göhrs <l.goehrs@pengutronix.de>
Closes: https://github.com/pengutronix/umpf/issues/63